### PR TITLE
[ci] sync template files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,9 @@ web_modules/
 .cache
 .parcel-cache
 
+# Astro 
+.astro
+
 # Next.js build output
 .next
 out

--- a/.prettierignore
+++ b/.prettierignore
@@ -35,3 +35,10 @@ coverage/
 # OS generated files
 .DS_Store
 Thumbs.db
+
+# Markdown and MDX files
+*.md
+*.mdx
+
+# Changelog
+.changeset


### PR DESCRIPTION
This PR syncs the specified GitHub template files from the [central repository](https://github.com/trueberryless-org/template-files).

### Changes:
- Merge pull request #34 from trueberryless-org/changeset-release/main - ([8dd8d74](https://github.com/trueberryless-org/template-files/commit/8dd8d7421367f055d5c7c0957e61760bf5467df1))
- add show-latest version starlight plugin - ([87c5ecd](https://github.com/trueberryless-org/template-files/commit/87c5ecda2ff5ab74cddb1a53bff90c062ba51d12))
- apply same changes to template file - ([473dbc7](https://github.com/trueberryless-org/template-files/commit/473dbc722d5c5c008e4c9d15820a19a36c75e131))
- only make deployment latest if no publish - ([f294bf4](https://github.com/trueberryless-org/template-files/commit/f294bf45c78ef680d9359cc5d5d5bfa6d76fbc57))
- add .astro to .gitignore - ([26c923f](https://github.com/trueberryless-org/template-files/commit/26c923fceb0e937a00a8854dfd18b76c665270e3))