### PR TITLE
feat: add starlight-sidebar-clickable-groups

### DIFF
--- a/.changeset/silly-cows-allow.md
+++ b/.changeset/silly-cows-allow.md
@@ -1,0 +1,5 @@
+---
+"template-files": patch
+---
+
+Add Starlight Sidebar Clickable Groups plugin to repos.json

--- a/repos.json
+++ b/repos.json
@@ -1039,6 +1039,141 @@
       ]
     },
     {
+      "name": "trueberryless-org/starlight-sidebar-clickable-groups",
+      "files": [
+        {
+          "path": "template-files/.changeset/config.json",
+          "targetPath": ".changeset/config.json",
+          "props": {
+            "repositoryName": "starlight-sidebar-clickable-groups",
+            "ignore": "[\"starlight-sidebar-clickable-groups-docs\"]"
+          }
+        },
+        {
+          "path": "template-files/.changeset/README.md",
+          "targetPath": ".changeset/README.md",
+          "props": {
+            "repositoryName": "starlight-sidebar-clickable-groups"
+          }
+        },
+        {
+          "path": "template-files/.github/CODEOWNERS",
+          "targetPath": ".github/CODEOWNERS"
+        },
+        {
+          "path": "template-files/.github/labeler.yaml",
+          "targetPath": ".github/labeler.yaml"
+        },
+        {
+          "path": "template-files/.github/renovate.json",
+          "targetPath": ".github/renovate.json"
+        },
+        {
+          "path": "template-files/.github/renovate.json",
+          "targetPath": ".github/renovate.json5",
+          "special": "delete"
+        },
+        {
+          "path": "template-files/.github/workflows/format.yaml",
+          "targetPath": ".github/workflows/format.yaml",
+          "props": {
+            "branchName": "main"
+          }
+        },
+        {
+          "path": "template-files/.github/workflows/labeler.yaml",
+          "targetPath": ".github/workflows/labeler.yaml"
+        },
+        {
+          "path": "template-files/.github/workflows/publish.yaml",
+          "targetPath": ".github/workflows/publish.yaml",
+          "props": {
+            "branchName": "main",
+            "repositoryName": "starlight-sidebar-clickable-groups",
+            "packageName": "starlight-sidebar-clickable-groups"
+          }
+        },
+        {
+          "path": "template-files/.github/workflows/welcome-bot.yaml",
+          "targetPath": ".github/workflows/welcome-bot.yaml",
+          "props": {
+            "branchName": "main"
+          }
+        },
+        {
+          "path": "template-files/.gitignore/Node.gitignore",
+          "targetPath": ".gitignore",
+          "special": "allow-additional-lines"
+        },
+        {
+          "path": "template-files/.prettierignore",
+          "targetPath": ".prettierignore",
+          "special": "allow-additional-lines"
+        },
+        {
+          "path": "template-files/.prettierrc/.prettierrc",
+          "targetPath": ".prettierrc"
+        },
+        {
+          "path": "template-files/package.json/package.manager.package.json",
+          "targetPath": "docs/package.json",
+          "special": "package.json"
+        },
+        {
+          "path": "template-files/LICENSE",
+          "targetPath": "LICENSE",
+          "props": {
+            "year": "2025"
+          }
+        },
+        {
+          "path": "template-files/package.json/changeset.package.json",
+          "targetPath": "package.json",
+          "special": "package.json"
+        },
+        {
+          "path": "template-files/package.json/package.manager.package.json",
+          "targetPath": "package.json",
+          "special": "package.json"
+        },
+        {
+          "path": "template-files/package.json/prettier.package.json",
+          "targetPath": "package.json",
+          "special": "package.json"
+        },
+        {
+          "path": "template-files/package.json/definition.package.json",
+          "targetPath": "package.json",
+          "special": "package.json",
+          "props": {
+            "packageName": "starlight-sidebar-clickable-groups-monorepo",
+            "repositoryName": "starlight-sidebar-clickable-groups"
+          }
+        },
+        {
+          "path": "template-files/package.json/definition.package.json",
+          "targetPath": "packages/starlight-sidebar-clickable-groups/package.json",
+          "special": "package.json",
+          "props": {
+            "packageName": "starlight-sidebar-clickable-groups",
+            "repositoryName": "starlight-sidebar-clickable-groups"
+          }
+        },
+        {
+          "path": "template-files/README.md",
+          "targetPath": "packages/starlight-sidebar-clickable-groups/README.md",
+          "special": "README.md"
+        },
+        {
+          "path": "template-files/pnpm-workspace.yaml",
+          "targetPath": "pnpm-workspace.yaml",
+          "props": {
+            "documentationFolder": "docs"
+          }
+        }
+      ]
+    },
+    {
       "name": "trueberryless-org/starlight-plugin-show-latest-version",
       "files": [
         {


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

- Closes # <!-- Add an issue number if this PR will close it. -->
- What does this PR change? Give us a brief description.
- Did you change something visual? A before/after screenshot can be helpful.

<!--
Here’s what will happen next:
One or more of our maintainers will take a look and may ask you to make changes.
We try to be responsive, but don’t worry if this takes a day or two.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Added configuration to onboard the “Starlight Sidebar Clickable Groups” plugin repository.
  - Bootstrapped standard monorepo scaffolding, CI workflows, dependency update automation, and code ownership via templates.
  - Recorded a patch entry in changesets (metadata only; no runtime changes).

- Documentation
  - Added template documentation (README and changeset guidance) for the new repository setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->