### PR TITLE
feat: make links to LICENSE in README.md absolute

### DIFF
--- a/.changeset/shaggy-animals-buy.md
+++ b/.changeset/shaggy-animals-buy.md
@@ -1,0 +1,5 @@
+---
+"template-files": minor
+---
+
+Make links to LICENSE in README.md absolute.

--- a/repos.json
+++ b/repos.json
@@ -90,7 +90,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "template-files"
+          }
         }
       ]
     },
@@ -209,7 +212,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "packages/starlight-recipes/README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "starlight-recipes"
+          }
         },
         {
           "path": "template-files/pnpm-workspace.yaml",
@@ -345,7 +351,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "packages/starlight-view-modes/README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "starlight-view-modes"
+          }
         },
         {
           "path": "template-files/pnpm-workspace.yaml",
@@ -481,7 +490,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "packages/starlight-cooler-credit/README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "starlight-cooler-credit"
+          }
         },
         {
           "path": "template-files/pnpm-workspace.yaml",
@@ -617,7 +629,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "packages/starlight-sidebar-topics-dropdown/README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "starlight-sidebar-topics-dropdown"
+          }
         },
         {
           "path": "template-files/pnpm-workspace.yaml",
@@ -753,7 +768,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "packages/starlight-sidebar-swipe/README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "starlight-sidebar-swipe"
+          }
         },
         {
           "path": "template-files/pnpm-workspace.yaml",
@@ -889,7 +907,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "packages/starlight-contributor-list/README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "starlight-contributor-list"
+          }
         },
         {
           "path": "template-files/pnpm-workspace.yaml",
@@ -1016,7 +1037,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "packages/starlight-automatic-overview-pages/README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "starlight-automatic-overview-pages"
+          }
         },
         {
           "path": "template-files/pnpm-workspace.yaml",
@@ -1152,7 +1176,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "packages/starlight-sidebar-clickable-groups/README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "starlight-sidebar-clickable-groups"
+          }
         },
         {
           "path": "template-files/pnpm-workspace.yaml",
@@ -1288,7 +1315,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "packages/starlight-latest-version/README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "starlight-latest-version"
+          }
         },
         {
           "path": "template-files/pnpm-workspace.yaml",
@@ -1424,7 +1454,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "packages/starlight-plugins-docs-components/README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "starlight-plugins-docs-components"
+          }
         },
         {
           "path": "template-files/pnpm-workspace.yaml",
@@ -1560,7 +1593,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "packages/starlight-theme-next/README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "starlight-theme-next"
+          }
         },
         {
           "path": "template-files/pnpm-workspace.yaml",
@@ -1817,7 +1853,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "packages/starlight-save-file-component/README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "starlight-save-file-component"
+          }
         },
         {
           "path": "template-files/pnpm-workspace.yaml",
@@ -1917,7 +1956,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "mutanuq"
+          }
         },
         {
           "path": "template-files/package.json/package.manager.package.json",
@@ -1999,7 +2041,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "blog"
+          }
         }
       ]
     },
@@ -2092,7 +2137,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "videos"
+          }
         },
         {
           "path": "template-files/package.json/package.manager.package.json",
@@ -2257,7 +2305,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "truzzles"
+          }
         }
       ]
     },
@@ -2343,7 +2394,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "trueberryless"
+          }
         }
       ]
     },
@@ -2420,7 +2474,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "true-tracker"
+          }
         }
       ]
     },
@@ -2513,7 +2570,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "github-activity"
+          }
         },
         {
           "path": "template-files/package.json/package.manager.package.json",
@@ -2615,7 +2675,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "starlight-subtle-top-level-items"
+          }
         },
         {
           "path": "template-files/package.json/package.manager.package.json",
@@ -2711,7 +2774,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "recent-releases"
+          }
         }
       ]
     },
@@ -2788,7 +2854,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "starlight-plugin-translations"
+          }
         }
       ]
     },
@@ -2878,7 +2947,10 @@
         {
           "path": "template-files/README.md",
           "targetPath": "README.md",
-          "special": "README.md"
+          "special": "README.md",
+          "props": {
+            "repo": "release-image-generator"
+          }
         }
       ]
     },

--- a/sync_templates.sh
+++ b/sync_templates.sh
@@ -55,6 +55,20 @@ for file_config in $(echo "$FILES" | jq -c '.[]'); do
   if [ "$special" == "README.md" ]; then
     echo "Special handling for README.md"
 
+    # Handle dynamic content replacement in README.md if "props" is specified
+    props=$(echo "$file_config" | jq -c '.props // empty')
+    processed_src=$(mktemp)
+    cp "$src_file" "$processed_src"
+
+    if [ -n "$props" ]; then
+      for key in $(echo "$props" | jq -r 'keys[]'); do
+        value=$(echo "$props" | jq -r --arg key "$key" '.[$key]')
+        placeholder="<%= $key %>"
+        echo "Replacing $placeholder with $value in $src_file..."
+        sed -i "s|$placeholder|$value|g" "$processed_src"
+      done
+    fi
+
     # Combine existing README.md with the License section
     if [ -f "$dest_file" ]; then
       # Create a temporary file to store the combined content

--- a/sync_templates.sh
+++ b/sync_templates.sh
@@ -73,14 +73,16 @@ for file_config in $(echo "$FILES" | jq -c '.[]'); do
     if [ -f "$dest_file" ]; then
       # Create a temporary file to store the combined content
       echo "Combining existing README.md with the License section..."
-      awk '/## License/,EOF' "$src_file" | tail -n +2 > license_content.md
+      awk '/## License/,EOF' "$processed_src" | tail -n +2 > license_content.md
       markdown-replace-section "$dest_file" "License" "$dest_file" < license_content.md
       rm -f license_content.md
     else
       # If no existing README.md, copy the template and add the License section
       echo "No existing README.md found. Creating a new one..."
-      cp "$src_file" "$dest_file"
+      cp "$processed_src" "$dest_file"
     fi
+
+    rm -f "$processed_src"
 
 
   elif [ "$special" == "package.json" ]; then

--- a/template-files/README.md
+++ b/template-files/README.md
@@ -2,4 +2,4 @@
 
 Licensed under the MIT license, Copyright © trueberryless.
 
-See [LICENSE](/LICENSE) for more information.
+See [LICENSE](https://github.com/trueberryless-org/<%= repo %>/blob/main/LICENSE) for more information.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for dynamic, repository-specific content in README templates; LICENSE links now use absolute GitHub URLs parameterized by repository name.
* **Chores**
  * Template sync now applies repository props to README templates during updates and cleans up temporary processing artifacts.
  * Added a release changeset marking a minor version bump for the template package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->