### PR TITLE
fix: only run tangled mirror on main (+ tags and workflow dipatch)

### DIFF
--- a/.changeset/little-geese-kick.md
+++ b/.changeset/little-geese-kick.md
@@ -2,4 +2,4 @@
 "template-files": patch
 ---
 
-Only run tangled mirror on main branch, errors otherwise.
+Limit tangled workflow trigger to main branch and tags.

--- a/.changeset/little-geese-kick.md
+++ b/.changeset/little-geese-kick.md
@@ -1,0 +1,5 @@
+---
+"template-files": patch
+---
+
+Only run tangled mirror on main branch, errors otherwise.

--- a/template-files/.github/workflows/tangle.yaml
+++ b/template-files/.github/workflows/tangle.yaml
@@ -1,8 +1,12 @@
 name: Tangle
 
 on:
-  push: {}
-  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to run only on the main branch and on tagged releases (manual dispatch still available); tangle/mirror runs will occur only when triggered on those refs.
* **Documentation**
  * Added a changeset entry documenting the behavior and patch-level bump for the template-files package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trueberryless-org/template-files/pull/303)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->